### PR TITLE
【ChatBox分解】ChatBoxSubmitコンポーネントの作成

### DIFF
--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -9,6 +9,7 @@ import { useSpeaker } from "../../hooks/useSpeaker.ts"
 import { messageHistoryType } from "../../types/index.ts"
 import { Spinner } from "../Spinner/Spinner.tsx"
 import { MicIcon } from "../MicIcon/MicIcon.tsx"
+import { ChatBoxSubmit } from "../ChatBoxSubmit/ChatBoxSubmit.tsx"
 
 interface IChatBoxProps {}
 
@@ -124,20 +125,6 @@ export const ChatBox: FC<IChatBoxProps> = () => {
     />
   )
 
-  const submitEl = listening ? (
-    <button type="button" className="chat-box-submit" disabled>
-      ◉
-    </button>
-  ) : (
-    <button
-      type="button"
-      className="chat-box-submit"
-      onClick={() => processThought(message)}
-    >
-      ▶
-    </button>
-  )
-
   // 「⌘ + enter」 or 「ctrl + enter」 で 送信
   const handleKeyDown = (e: KeyboardEvent) => {
     switch (e.key) {
@@ -189,7 +176,11 @@ export const ChatBox: FC<IChatBoxProps> = () => {
       </section>
       <section className="chat-box-footer">
         {inputEl}
-        {submitEl}
+        <ChatBoxSubmit
+          listening={listening}
+          message={message}
+          clickHandle={processThought}
+        />
       </section>
 
       <Spinner visible={loading} />

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -221,7 +221,7 @@ export const ChatBox: FC<IChatBoxProps> = () => {
       <section className="chat-box-footer">
         {inputEl}
         <ChatBoxSubmit
-          listening={listening}
+          recoding={recoding}
           message={message}
           clickHandle={processThought}
         />

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -10,12 +10,14 @@ import { messageHistoryType } from "../../types/index.ts"
 import { Spinner } from "../Spinner/Spinner.tsx"
 import { MicIcon } from "../MicIcon/MicIcon.tsx"
 import { ChatBoxSubmit } from "../ChatBoxSubmit/ChatBoxSubmit.tsx"
+import { RecognitionSwitch } from "../RecognitionSwitch/RecognitionSwitch.tsx"
 
 interface IChatBoxProps {}
 
 export const ChatBox: FC<IChatBoxProps> = () => {
   const [message, setMessage] = useState("")
   const [loading, setLoading] = useState(false)
+  const [recoding, setRecoding] = useState(false)
   const [messageHistories, setMessageHistories] = useState<
     messageHistoryType[]
   >([])
@@ -58,7 +60,39 @@ export const ChatBox: FC<IChatBoxProps> = () => {
     }
   }
 
-  const { transcript, listening, resetTranscript } = useSpeechRecognition()
+  const commands = [
+    {
+      command: "スタート",
+      matchInterim: true,
+      callback: () => {
+        if (recoding) {
+          return
+        }
+        console.log("録音開始")
+        resetTranscript()
+        setRecoding(true)
+      },
+    },
+    {
+      command: "ストップ",
+      matchInterim: true,
+      callback: () => {
+        if (!recoding) {
+          return
+        }
+        setRecoding(false)
+        console.log("録音終了")
+        const input = transcript.replace("/(*.)ストップ$/u", "$1")
+        console.log(input)
+        processThought(input)
+        resetTranscript()
+      },
+    },
+  ]
+
+  const { transcript, listening, resetTranscript } = useSpeechRecognition({
+    commands,
+  })
 
   // メッセージが追加されたら、一番最新のメッセージの箇所までスクロールする
   const scrollToCurrentChatBox = () => {
@@ -68,12 +102,17 @@ export const ChatBox: FC<IChatBoxProps> = () => {
     }
   }
 
-  const speechHandle = async () => {
+  // 音声認識APIのON/OFF切り替え
+  const recognitionHandle = () => {
     if (listening) {
       stopSpeech()
     } else {
       startSpeech()
     }
+  }
+
+  const speechHandle = async () => {
+    setRecoding(!recoding)
   }
 
   const startSpeech = async () => {
@@ -85,7 +124,6 @@ export const ChatBox: FC<IChatBoxProps> = () => {
 
   const stopSpeech = async () => {
     await SpeechRecognition.stopListening()
-    console.log(transcript)
     if (transcript) {
       postMessage(transcript)
       await processThought(transcript)
@@ -106,7 +144,7 @@ export const ChatBox: FC<IChatBoxProps> = () => {
     ])
   }
 
-  const inputEl = listening ? (
+  const inputEl = recoding ? (
     <input
       type="text"
       readOnly
@@ -118,7 +156,7 @@ export const ChatBox: FC<IChatBoxProps> = () => {
     <input
       type="text"
       className="chat-box-input"
-      readOnly={listening}
+      readOnly={recoding}
       value={message}
       disabled={loading}
       onChange={(e) => setMessage(e.target.value)}
@@ -155,13 +193,19 @@ export const ChatBox: FC<IChatBoxProps> = () => {
 
   return (
     <div className="chat-box">
+      <RecognitionSwitch
+        listening={listening}
+        disabled={recoding}
+        recognitionHandle={recognitionHandle}
+      />
       <section className="chat-box-header">
         <button
           type="button"
-          className={listening ? "speech-btn rec" : "speech-btn wait"}
+          disabled={!listening}
+          className={recoding ? "speech-btn rec" : "speech-btn wait"}
           onClick={speechHandle}
         >
-          {listening ? "音声入力 終了 ■" : "音声入力 開始 ◉"}
+          {recoding ? "音声入力 終了 ■" : "音声入力 開始 ◉"}
         </button>
       </section>
       <section className="chat-box-body" id="chatBoxBody">
@@ -172,7 +216,7 @@ export const ChatBox: FC<IChatBoxProps> = () => {
             </div>
           )
         })}
-        <MicIcon visible={listening} />
+        <MicIcon visible={recoding} />
       </section>
       <section className="chat-box-footer">
         {inputEl}

--- a/src/components/ChatBoxSubmit/ChatBoxSubmit.test.tsx
+++ b/src/components/ChatBoxSubmit/ChatBoxSubmit.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import {ChatBoxSubmit} from './ChatBoxSubmit';
+import '@testing-library/jest-dom/extend-expect'
+
+describe('ChatBoxSubmit', () => {
+  it('should render', () => {
+    render(<ChatBoxSubmit />);
+  });
+});

--- a/src/components/ChatBoxSubmit/ChatBoxSubmit.test.tsx
+++ b/src/components/ChatBoxSubmit/ChatBoxSubmit.test.tsx
@@ -1,9 +1,23 @@
-import { render, screen } from '@testing-library/react';
-import {ChatBoxSubmit} from './ChatBoxSubmit';
-import '@testing-library/jest-dom/extend-expect'
+import { render } from "@testing-library/react"
+import { ChatBoxSubmit } from "./ChatBoxSubmit"
+import "@testing-library/jest-dom/extend-expect"
 
-describe('ChatBoxSubmit', () => {
-  it('should render', () => {
-    render(<ChatBoxSubmit />);
-  });
-});
+const mockFunc = (m: string): void => {
+  console.log(m)
+}
+
+describe("ChatBoxSubmit", () => {
+  it("recoding TRUE CASE : 録音ボタン", () => {
+    const { getByText, getByTestId } = render(
+      <ChatBoxSubmit recoding={true} message="ok" clickHandle={mockFunc} />
+    )
+    expect(getByText("◉")).toBeInTheDocument()
+    expect(getByTestId("button")).toBeDisabled()
+  })
+  it("recoding FALSE CASE : 再生ボタン", () => {
+    const { getByText } = render(
+      <ChatBoxSubmit recoding={false} message="ok" clickHandle={mockFunc} />
+    )
+    expect(getByText("▶")).toBeInTheDocument()
+  })
+})

--- a/src/components/ChatBoxSubmit/ChatBoxSubmit.tsx
+++ b/src/components/ChatBoxSubmit/ChatBoxSubmit.tsx
@@ -1,0 +1,28 @@
+import { FC } from "react"
+import "./ChatBoxSubmit.scss"
+
+interface IChatBoxSubmitProps {
+  listening: boolean
+  message: string
+  clickHandle: (v: string) => void
+}
+
+export const ChatBoxSubmit: FC<IChatBoxSubmitProps> = ({
+  listening,
+  message,
+  clickHandle,
+}) => {
+  return listening ? (
+    <button type="button" className="chat-box-submit" disabled>
+      ◉
+    </button>
+  ) : (
+    <button
+      type="button"
+      className="chat-box-submit"
+      onClick={() => clickHandle(message)}
+    >
+      ▶
+    </button>
+  )
+}

--- a/src/components/ChatBoxSubmit/ChatBoxSubmit.tsx
+++ b/src/components/ChatBoxSubmit/ChatBoxSubmit.tsx
@@ -2,17 +2,17 @@ import { FC } from "react"
 import "./ChatBoxSubmit.scss"
 
 interface IChatBoxSubmitProps {
-  listening: boolean
+  recoding: boolean
   message: string
   clickHandle: (v: string) => void
 }
 
 export const ChatBoxSubmit: FC<IChatBoxSubmitProps> = ({
-  listening,
+  recoding,
   message,
   clickHandle,
 }) => {
-  return listening ? (
+  return recoding ? (
     <button type="button" className="chat-box-submit" disabled>
       ◉
     </button>

--- a/src/components/ChatBoxSubmit/ChatBoxSubmit.tsx
+++ b/src/components/ChatBoxSubmit/ChatBoxSubmit.tsx
@@ -13,12 +13,18 @@ export const ChatBoxSubmit: FC<IChatBoxSubmitProps> = ({
   clickHandle,
 }) => {
   return recoding ? (
-    <button type="button" className="chat-box-submit" disabled>
+    <button
+      type="button"
+      data-testid="button"
+      className="chat-box-submit"
+      disabled
+    >
       ◉
     </button>
   ) : (
     <button
       type="button"
+      data-testid="button"
       className="chat-box-submit"
       onClick={() => clickHandle(message)}
     >

--- a/src/components/ChatBoxSubmit/index.ts
+++ b/src/components/ChatBoxSubmit/index.ts
@@ -1,0 +1,1 @@
+export * from './ChatBoxSubmit';

--- a/src/components/RecognitionSwitch/RecognitionSwitch.scss
+++ b/src/components/RecognitionSwitch/RecognitionSwitch.scss
@@ -1,0 +1,53 @@
+.recognition-switch {
+  position: fixed;
+  top: 30px;
+  translate: -50%;
+  height: 36px;
+  width: 24px;
+  background-color: #ccc;
+  cursor: pointer;
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    display: inline-block;
+    height: 36px;
+    width: 36px;
+    border-radius: 50%;
+    background-color: #ccc;
+    translate: -50% 0;
+  }
+  &::before {
+    left: 0;
+  }
+  &::after {
+    left: 100%;
+  }
+  &.disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+  > input[type="checkbox"] + label {
+    content: "";
+    position: absolute;
+    top: 0;
+    height: 36px;
+    width: 36px;
+    border-radius: 50%;
+    background-color: #aaa;
+    translate: -50%;
+    z-index: 1;
+    border: 3px solid #ccc;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 0.8rem;
+  }
+  > input[type="checkbox"]:checked + label {
+    background-color: #c00;
+    color: #fff;
+    left: 100%;
+  }
+}

--- a/src/components/RecognitionSwitch/RecognitionSwitch.test.tsx
+++ b/src/components/RecognitionSwitch/RecognitionSwitch.test.tsx
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/react"
+import { RecognitionSwitch } from "./RecognitionSwitch"
+import "@testing-library/jest-dom/extend-expect"
+
+describe("RecognitionSwitch", () => {
+  it("status OFF", () => {
+    const { getByText } = render(
+      <RecognitionSwitch
+        listening={false}
+        disabled={false}
+        recognitionHandle={() => {}}
+      />
+    )
+    expect(getByText("OFF")).toBeInTheDocument()
+  })
+
+  it("status ON", () => {
+    const { getByText } = render(
+      <RecognitionSwitch
+        listening={true}
+        disabled={false}
+        recognitionHandle={() => {}}
+      />
+    )
+    expect(getByText("ON")).toBeInTheDocument()
+  })
+})

--- a/src/components/RecognitionSwitch/RecognitionSwitch.tsx
+++ b/src/components/RecognitionSwitch/RecognitionSwitch.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react"
+import "./RecognitionSwitch.scss"
+
+interface IRecognitionSwitchProps {
+  listening: boolean
+  disabled: boolean
+  recognitionHandle: () => void
+}
+
+export const RecognitionSwitch: FC<IRecognitionSwitchProps> = ({
+  listening,
+  disabled,
+  recognitionHandle,
+}) => {
+  return (
+    <div
+      className={`recognition-switch ${disabled ? "disabled" : ""}`}
+      onClick={recognitionHandle}
+      data-testid="toggle"
+    >
+      <input
+        type="checkbox"
+        onChange={() => (listening = !listening)}
+        checked={listening}
+      />
+      <label>{listening ? "ON" : "OFF"}</label>
+    </div>
+  )
+}

--- a/src/components/RecognitionSwitch/index.ts
+++ b/src/components/RecognitionSwitch/index.ts
@@ -1,0 +1,1 @@
+export * from './RecognitionSwitch';


### PR DESCRIPTION
## 実装内容
- ChatBox内にあるSubmitボタンをコンポーネントへ分割
- UnitTestの作成

## レビューしてほしいこと
- 分割したコンポーネントの単位に誤りがないか
- テスト内容が充足しているか

## UML図
なし

## 関連issue
なし

## 補足
<img width="408" alt="image" src="https://github.com/Greek-Academy/team-2/assets/44972311/dc60f33b-b473-466a-be97-1345efb0f50d">
