### PR TITLE
SpeakerButtonのユニットテストを追加しました。

### DIFF
--- a/src/components/SpeakerButton/SpeakerButton.test.tsx
+++ b/src/components/SpeakerButton/SpeakerButton.test.tsx
@@ -13,6 +13,7 @@ describe('SpeakerButton', () => {
       state: true,
       handlePlay: handlePlayMock,
     })
+    
     render(<SpeakerButton stringToRead='abcde'/>)
     const speakerButton = screen.getByRole("button")
     expect(speakerButton).toBeEnabled()
@@ -33,7 +34,7 @@ test("Test when stringToRead is correctly entered and status is true.(handlePlay
     expect(handlePlayMock).toHaveBeenCalledWith("うなぎ二千円を３人で割り勘して下さい")
 })
 
-test("Test when status is TRUE and stringToRead is null.(Disabled)", () => {
+test("Test when status is TRUE and stringToRead is blank.(Disabled)", () => {
   const handlePlayMock = jest.fn()
   mockUseSpeaker.mockReturnValueOnce({
     state: true,
@@ -42,8 +43,7 @@ test("Test when status is TRUE and stringToRead is null.(Disabled)", () => {
 
   render(<SpeakerButton stringToRead="" />)
   const speakerButton = screen.getByRole("button")
-  fireEvent.click(speakerButton)
-
+  
   expect(speakerButton).toBeDisabled()
 })
 
@@ -56,8 +56,7 @@ test("Test when status is FALSE and stringToRead contains a string.(Disabled)", 
 
   render(<SpeakerButton stringToRead="あいうえお" />)
   const speakerButton = screen.getByRole("button")
-  fireEvent.click(speakerButton)
-
+  
   expect(speakerButton).toBeDisabled()
 })
 
@@ -70,12 +69,11 @@ test("Test when status is FALSE and stringToRead contains a string.(Button Label
 
   render(<SpeakerButton stringToRead="あいうえお" />)
   const speakerButton = screen.getByRole("button")
-  fireEvent.click(speakerButton)
-
+  
   expect(speakerButton).toHaveTextContent("音声出力非対応")
 })
 
-test("Test when status is TRUE and stringToRead is null.(Button Label)", () => {
+test("Test when status is TRUE and stringToRead is blank.(Button Label)", () => {
   const handlePlayMock = jest.fn()
   mockUseSpeaker.mockReturnValueOnce({
     state: true,
@@ -84,8 +82,7 @@ test("Test when status is TRUE and stringToRead is null.(Button Label)", () => {
 
   render(<SpeakerButton stringToRead="" />)
   const speakerButton = screen.getByRole("button")
-  fireEvent.click(speakerButton)
-
+  
   expect(speakerButton).toHaveTextContent("音声出力非対応")
 })
 
@@ -100,5 +97,5 @@ test("Test when stringToRead is correctly entered and status is true.(Button Lab
   const speakerButton = screen.getByRole("button")
   fireEvent.click(speakerButton)
 
-  expect(speakerButton).toHaveTextContent("音声テスト")
+  expect(speakerButton).toHaveTextContent("音声読上げ")
 })

--- a/src/components/SpeakerButton/SpeakerButton.test.tsx
+++ b/src/components/SpeakerButton/SpeakerButton.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useSpeaker } from "../../hooks/useSpeaker"
+import { SpeakerButton } from './SpeakerButton'
+import '@testing-library/jest-dom/extend-expect'
+
+jest.mock("../../hooks/useSpeaker")
+
+const mockUseSpeaker = useSpeaker as jest.MockedFunction<typeof useSpeaker>
+describe('SpeakerButton', () => {
+  it('SpeakerButton render Test', () => {
+    const handlePlayMock = jest.fn()
+    mockUseSpeaker.mockReturnValueOnce({
+      state: true,
+      handlePlay: handlePlayMock,
+    })
+    render(<SpeakerButton stringToRead='abcde'/>)
+    const speakerButton = screen.getByRole("button")
+    expect(speakerButton).toBeEnabled()
+  });
+});
+
+test("Test when stringToRead is correctly entered and status is true.(handlePlay Calling)", () => {
+    const handlePlayMock = jest.fn()
+    mockUseSpeaker.mockReturnValueOnce({
+      state: true,
+      handlePlay: handlePlayMock,
+    })
+  
+    render(<SpeakerButton stringToRead="うなぎ二千円を３人で割り勘して下さい" />)
+    const speakerButton = screen.getByRole("button")
+    fireEvent.click(speakerButton)
+  
+    expect(handlePlayMock).toHaveBeenCalledWith("うなぎ二千円を３人で割り勘して下さい")
+})
+
+test("Test when status is TRUE and stringToRead is null.(Disabled)", () => {
+  const handlePlayMock = jest.fn()
+  mockUseSpeaker.mockReturnValueOnce({
+    state: true,
+    handlePlay: handlePlayMock,
+  })
+
+  render(<SpeakerButton stringToRead="" />)
+  const speakerButton = screen.getByRole("button")
+  fireEvent.click(speakerButton)
+
+  expect(speakerButton).toBeDisabled()
+})
+
+test("Test when status is FALSE and stringToRead contains a string.(Disabled)", () => {
+  const handlePlayMock = jest.fn()
+  mockUseSpeaker.mockReturnValueOnce({
+    state: false,
+    handlePlay: handlePlayMock,
+  })
+
+  render(<SpeakerButton stringToRead="あいうえお" />)
+  const speakerButton = screen.getByRole("button")
+  fireEvent.click(speakerButton)
+
+  expect(speakerButton).toBeDisabled()
+})
+
+test("Test when status is FALSE and stringToRead contains a string.(Button Label)", () => {
+  const handlePlayMock = jest.fn()
+  mockUseSpeaker.mockReturnValueOnce({
+    state: false,
+    handlePlay: handlePlayMock,
+  })
+
+  render(<SpeakerButton stringToRead="あいうえお" />)
+  const speakerButton = screen.getByRole("button")
+  fireEvent.click(speakerButton)
+
+  expect(speakerButton).toHaveTextContent("音声出力非対応")
+})
+
+test("Test when status is TRUE and stringToRead is null.(Button Label)", () => {
+  const handlePlayMock = jest.fn()
+  mockUseSpeaker.mockReturnValueOnce({
+    state: true,
+    handlePlay: handlePlayMock,
+  })
+
+  render(<SpeakerButton stringToRead="" />)
+  const speakerButton = screen.getByRole("button")
+  fireEvent.click(speakerButton)
+
+  expect(speakerButton).toHaveTextContent("音声出力非対応")
+})
+
+test("Test when stringToRead is correctly entered and status is true.(Button Label)", () => {
+  const handlePlayMock = jest.fn()
+  mockUseSpeaker.mockReturnValueOnce({
+    state: true,
+    handlePlay: handlePlayMock,
+  })
+
+  render(<SpeakerButton stringToRead="ビール3000円を２人で割り勘して下さい" />)
+  const speakerButton = screen.getByRole("button")
+  fireEvent.click(speakerButton)
+
+  expect(speakerButton).toHaveTextContent("音声テスト")
+})

--- a/src/components/SpeakerButton/SpeakerButton.tsx
+++ b/src/components/SpeakerButton/SpeakerButton.tsx
@@ -9,6 +9,6 @@ export const SpeakerButton = (props: SpeakerButtonProps) => {
 
     return (
         <button type="button" disabled={disabled}
-                onClick={() => handlePlay(props.stringToRead || "テスト")}>{disabled ? '音声出力非対応' : '音声テスト'}</button>
+                onClick={() => handlePlay(props.stringToRead || "テスト")}>{disabled ? '音声出力非対応' : '音声読上げ'}</button>
     );
 };


### PR DESCRIPTION
## 実装内容
Speaker Buttonのユニットテストを実装

## レビューしてほしいこと
Speaker Buttonが押された時の振る舞いをテストしています。テストパターンは以下にしていますが、足りない場合はご指摘ください。
1. SpeakerButtonのrenderテスト
2. status=TRUEでstringToReadに正しく文章が入っていた時(handlePlayが呼ばれるか？)
3. status=TRUEだがstringToReadが空欄だった時(ButtonがDisableか？)
4. status=FALSEでstringToReadには正しく文字列が入っていた時(ButtonがDisableか？)
5. status=FALSEでstringToReadには正しく文字列が入っていた時(Buttonのラベルが「音声出力非対応」か？)
6. status=TRUEだがstringToReadが空欄だった時(Buttonのラベルが「音声出力非対応」か？)
7. status=TRUEでstringToReadに正しく文章が入っていた時(Buttonのラベルが「音声テスト」か？)

テスト結果↓
![image](https://github.com/Greek-Academy/team-2/assets/78740184/e5e9f3ce-8a9b-45aa-beb4-d4399b1f7f2c)

## UML図
→ありません

## 関連issue
→ありません

## 補足
最後のテストに使っているButtonのラベルですが、表示はされないですが「音声テスト」→「音声読上げ」や「再生」などの文字にした方が良いかと思います。